### PR TITLE
existing renamer tests

### DIFF
--- a/src/existing_renamer.py
+++ b/src/existing_renamer.py
@@ -20,15 +20,16 @@ class ExistingRenamer:
 
             series = self.sonarr_cli.get_serie()
 
-            if series is []:
+            if len(series) == 0:
                 logger.error("Sonarr returned empty series list")
             else:
                 logger.debug("Retrieved series list")
+
             for show in sorted(series, key=lambda s: s.title):
                 with logger.contextualize(series=show.title):
                     episode_list = self.sonarr_cli.get_episode(show.id)
 
-                    if episode_list is []:
+                    if len(episode_list) == 0:
                         logger.error("Error fetching episode list")
                         continue
                     else:
@@ -47,7 +48,7 @@ class ExistingRenamer:
                             batch_rename.append(
                                 Rename(file_info["id"], season_episode_number)
                             )
-                            logger.info(f"{season_episode_number} Queing for rename")
+                            logger.info(f"{season_episode_number} Queuing for rename")
 
                     if batch_rename.has_files_to_rename():
                         self.sonarr_cli.rename_files(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pytest
 from pycliarr.api import SonarrCli, SonarrSerieItem
+from pycliarr.api.base_api import json_data
 
 
 @pytest.fixture
@@ -14,11 +15,27 @@ def get_serie(mocker) -> None:
 
 
 def episode_data(
-    id: int, title: str, airDateDelta: timedelta, seasonNumber: str
-) -> dict:
+    id: int,
+    title: str,
+    airDateDelta: timedelta,
+    seasonNumber: str = 1,
+    episodeNumber: int = 1,
+    hasFile: bool = True,
+    episodeFileId: int = 1,
+) -> json_data:
     return dict(
         id=id,
         title=title,
         airDateUtc=(datetime.now(timezone.utc) + airDateDelta).isoformat(),
         seasonNumber=seasonNumber,
+        episodeNumber=episodeNumber,
+        hasFile=hasFile,
+        episodeFileId=episodeFileId,
+    )
+
+
+def file_info(id: int, file_name: str) -> json_data:
+    return dict(
+        id=id,
+        path=f"/path/to/{file_name}",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+import pytest
+from pycliarr.api import SonarrCli, SonarrSerieItem
+
+
+@pytest.fixture
+def get_serie(mocker) -> None:
+    series: List[SonarrSerieItem] = [
+        SonarrSerieItem(id=1, title="test title", status="continuing")
+    ]
+    mocker.patch.object(SonarrCli, "get_serie").return_value = series
+
+
+def episode_data(
+    id: int, title: str, airDateDelta: timedelta, seasonNumber: str
+) -> dict:
+    return dict(
+        id=id,
+        title=title,
+        airDateUtc=(datetime.now(timezone.utc) + airDateDelta).isoformat(),
+        seasonNumber=seasonNumber,
+    )

--- a/tests/test_existing_renamer.py
+++ b/tests/test_existing_renamer.py
@@ -1,0 +1,158 @@
+import logging
+from datetime import timedelta
+from typing import List
+
+from existing_renamer import ExistingRenamer
+from pycliarr.api import SonarrCli
+from pycliarr.api.base_api import json_data
+
+from tests.conftest import episode_data, file_info
+
+
+class TestExistingRenamer:
+    def test_no_series_returned(self, caplog, mocker) -> None:
+        mocker.patch.object(SonarrCli, "get_serie").return_value = []
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "Starting Existing Renamer" in caplog.text
+        assert "Sonarr returned empty series list" in caplog.text
+        assert "Finished Existing Renamer" in caplog.text
+        assert not rename_files.called
+
+    def test_when_series_returned_no_episodes(self, get_serie, caplog, mocker) -> None:
+        mocker.patch.object(SonarrCli, "get_episode").return_value = []
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "Starting Existing Renamer" in caplog.text
+        assert "Retrieved series list" in caplog.text
+        assert "Error fetching episode list" in caplog.text
+        assert not rename_files.called
+
+    def test_when_episodes_filtered_out(self, get_serie, caplog, mocker) -> None:
+        episodes: List[json_data] = [
+            episode_data(
+                id=1,
+                title="TBA",
+                airDateDelta=timedelta(hours=2),
+                seasonNumber=0,
+            ),
+            episode_data(
+                id=2,
+                title="TBA",
+                airDateDelta=timedelta(hours=8),
+            ),
+            dict(id=3, title="NOT TBA", airDateUtc=None, seasonNumber=1, hasFile=False),
+        ]
+        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "Starting Existing Renamer" in caplog.text
+        assert "Retrieved series list" in caplog.text
+        assert "No rename needed" in caplog.text
+        assert not rename_files.called
+
+    def test_when_episode_file_name_contains_TBA(
+        self, get_serie, caplog, mocker
+    ) -> None:
+        episodes: List[json_data] = [
+            episode_data(
+                id=1,
+                title="NOT TBA",
+                airDateDelta=timedelta(days=-1),
+                seasonNumber=1,
+            ),
+        ]
+        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        file: json_data = file_info(
+            id=1,
+            file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
+        )
+
+        mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "S01E01 Queuing for rename" in caplog.text
+        assert "Renaming S01E01" in caplog.text
+        rename_files.assert_called_once_with([1], 1)
+
+    def test_when_renaming_multiple_files(self, get_serie, caplog, mocker) -> None:
+        episodes: List[json_data] = [
+            episode_data(
+                id=1,
+                title="NOT TBA",
+                airDateDelta=timedelta(days=-1),
+                seasonNumber=1,
+                episodeNumber=1,
+            ),
+            episode_data(
+                id=2,
+                title="NOT TBA",
+                airDateDelta=timedelta(days=-1),
+                seasonNumber=1,
+                episodeNumber=2,
+            ),
+        ]
+        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        file1: json_data = file_info(
+            id=1,
+            file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
+        )
+
+        file2: json_data = file_info(
+            id=2,
+            file_name="The Series Titles (2010) - S01E02 - TBA.mkv",
+        )
+
+        get_episode_file = mocker.patch.object(SonarrCli, "get_episode_file")
+        get_episode_file.return_value = file1
+        get_episode_file.side_effect = [file1, file2]
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "S01E01 Queuing for rename" in caplog.text
+        assert "S01E02 Queuing for rename" in caplog.text
+        assert "Renaming S01E01, S01E02" in caplog.text
+        rename_files.assert_called_once_with([1, 2], 1)
+
+    def test_when_episode_file_name_does_not_contain_TBA(
+        self, get_serie, caplog, mocker
+    ) -> None:
+        episodes: List[json_data] = [
+            episode_data(
+                id=1,
+                title="NOT TBA",
+                airDateDelta=timedelta(days=-1),
+                seasonNumber=1,
+            ),
+        ]
+        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+        file: json_data = file_info(
+            id=1,
+            file_name="The Series Titles (2010) - S01E01 - Episode1.mkv",
+        )
+
+        mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
+
+        with caplog.at_level(logging.DEBUG):
+            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+        assert "No rename needed" in caplog.text
+        assert not rename_files.called

--- a/tests/test_series_scanner.py
+++ b/tests/test_series_scanner.py
@@ -59,13 +59,11 @@ class TestSeriesScanner:
                 id=1,
                 title="TBA",
                 airDateDelta=timedelta(hours=8),
-                seasonNumber=1,
             ),
             episode_data(
                 id=2,
                 title="title",
                 airDateDelta=timedelta(hours=-2),
-                seasonNumber=1,
             ),
             episode_data(
                 id=3,

--- a/tests/test_series_scanner.py
+++ b/tests/test_series_scanner.py
@@ -1,31 +1,15 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import List
 
-import pytest
 from pycliarr.api import SonarrCli, SonarrSerieItem
 from pycliarr.api.base_api import json_data
 from series_scanner import SeriesScanner
 
+from tests.conftest import episode_data
+
 
 class TestSeriesScanner:
-    @pytest.fixture
-    def get_serie(self, mocker) -> None:
-        series: List[SonarrSerieItem] = [
-            SonarrSerieItem(id=1, title="test title", status="continuing")
-        ]
-        mocker.patch.object(SonarrCli, "get_serie").return_value = series
-
-    def episode_data(
-        self, id: int, title: str, airDateDelta: timedelta, seasonNumber: str
-    ) -> dict:
-        return dict(
-            id=id,
-            title=title,
-            airDateUtc=(datetime.now(timezone.utc) + airDateDelta).isoformat(),
-            seasonNumber=seasonNumber,
-        )
-
     def test_no_series_returned(self, caplog, mocker) -> None:
         mocker.patch.object(SonarrCli, "get_serie").return_value = []
         with caplog.at_level(logging.DEBUG):
@@ -71,19 +55,19 @@ class TestSeriesScanner:
 
     def test_when_episodes_filtered_out(self, get_serie, caplog, mocker) -> None:
         episodes: List[json_data] = [
-            self.episode_data(
+            episode_data(
                 id=1,
                 title="TBA",
                 airDateDelta=timedelta(hours=8),
                 seasonNumber=1,
             ),
-            self.episode_data(
+            episode_data(
                 id=2,
                 title="title",
                 airDateDelta=timedelta(hours=-2),
                 seasonNumber=1,
             ),
-            self.episode_data(
+            episode_data(
                 id=3,
                 title="TBA",
                 airDateDelta=timedelta(hours=2),
@@ -108,7 +92,7 @@ class TestSeriesScanner:
 
     def test_when_tba_episode_is_airing_soon(self, get_serie, caplog, mocker) -> None:
         episodes: List[json_data] = [
-            self.episode_data(
+            episode_data(
                 id=1,
                 title="TBA",
                 airDateDelta=timedelta(hours=2),
@@ -130,7 +114,7 @@ class TestSeriesScanner:
         self, get_serie, caplog, mocker
     ) -> None:
         episodes: List[json_data] = [
-            self.episode_data(
+            episode_data(
                 id=1,
                 title="TBA",
                 airDateDelta=timedelta(days=-1),


### PR DESCRIPTION
- **move fixture and method into conftest for shared usage**
- **100% coverage of existing_renamer**
