### PR TITLE
Redo existing_renamer, add additional check for series_scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,7 +303,7 @@ cython_debug/
 
 ### Python Patch ###
 # Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
-#poetry.toml
+poetry.toml
 
 # ruff
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To solve this, I created this app
 ## How it works
 
 ### Series Scanner
-This app uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
+This job uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
 
 * Iterate over continuing [series](https://sonarr.tv/docs/api/#/Series/get_api_v3_series)
   * If a series has an episode airing within `config.sonarr[].series_scanner.hours_before_air`
@@ -47,17 +47,11 @@ This should prevent too many API calls to the TVDB, refreshing individual series
 
 ### Existing Renamer
 
-This is basically the opposite functionality of the series scanner. This will check existing files for a `\bTBA\b` regex match, and if found, the file will be renamed
-
-This app uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
+This job uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
 
 * Iterate over all [series](https://sonarr.tv/docs/api/#/Series/get_api_v3_series)
-  * Ignores episodes that do not have files, or episodes that have TBA title
-* Renames are batched up, per series
-  * regex check on the episode filename
-    * if filename matches `\bTBA\b`
-    * then the file is added to current series batch rename
-  * Once all episodes of a series have been checked, then episodes that matched the regex will be renamed via Sonarr
+  * Checks if any episodes need to be [renamed](https://sonarr.tv/docs/api/#/RenameEpisode/get_api_v3_rename)
+  * Triggers a rename on any episodes that need be renamed (per series)
 
 ### Usage
 

--- a/src/models/batch_rename.py
+++ b/src/models/batch_rename.py
@@ -5,13 +5,17 @@ from models.rename import Rename
 
 class BatchRename:
     def __init__(self):
-        self.files_to_rename = []
+        self.files_to_rename: List[Rename] = []
 
-    def append(self, rename: Rename):
-        self.files_to_rename.append(rename)
+    def append(self, file_id, season_number, episode_numbers):
+        self.files_to_rename.append(Rename(file_id, season_number, episode_numbers))
 
     def get_log_message(self) -> str:
-        episode_list = [rename.season_episode_number for rename in self.files_to_rename]
+        episode_list: List[str] = [
+            f"S{str(rename.season_number).zfill(2)}E"
+            + "-".join([str(ep).zfill(2) for ep in rename.episode_numbers])
+            for rename in self.files_to_rename
+        ]
         return ", ".join(episode_list)
 
     def get_file_ids(self) -> List[int]:

--- a/src/models/rename.py
+++ b/src/models/rename.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass()
 class Rename:
     file_id: int
-    season_episode_number: str
+    season_number: int
+    episode_numbers: List[int]

--- a/src/series_scanner.py
+++ b/src/series_scanner.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from dateutil import parser
 from loguru import logger
 from pycliarr.api import SonarrCli
+from pycliarr.api.base_api import json_data
 
 
 class SeriesScanner:
@@ -13,6 +14,15 @@ class SeriesScanner:
 
     def scan(self) -> None:
         with logger.contextualize(instance=self.name):
+            mediamanagement: json_data = self.sonarr_cli.request_get(
+                path="/api/v3/config/mediamanagement"
+            )
+
+            if not mediamanagement["episodeTitleRequired"]:
+                logger.error("Episode Title Required is not set to always")
+                logger.error("Exiting Series Scan")
+                return
+
             logger.info("Starting Series Scan")
 
             series = self.sonarr_cli.get_serie()

--- a/tests/models/test_batch_rename.py
+++ b/tests/models/test_batch_rename.py
@@ -1,35 +1,43 @@
+import pytest
 from batch_rename import BatchRename
-from rename import Rename
 
 
 class TestBatchRename:
-    def test_empty_list_has_files_to_rename_test(self) -> None:
-        batch_rename = BatchRename()
+    @pytest.fixture
+    def batch_rename(self) -> BatchRename:
+        return BatchRename()
+
+    def test_empty_list_has_files_to_rename_test(self, batch_rename) -> None:
         assert not batch_rename.has_files_to_rename()
 
-    def test_has_files_to_rename(self) -> None:
-        batch_rename = BatchRename()
-        batch_rename.append(Rename(1, "S01E01"))
+    def test_has_files_to_rename(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
         assert batch_rename.has_files_to_rename()
 
-    def test_singular_get_log_msg(self) -> None:
-        batch_rename = BatchRename()
-        batch_rename.append(Rename(1, "S01E01"))
+    def test_singular_get_log_msg(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
         assert batch_rename.get_log_message() == "S01E01"
 
-    def test_multiples_get_log_msg(self) -> None:
-        batch_rename = BatchRename()
-        batch_rename.append(Rename(1, "S01E01"))
-        batch_rename.append(Rename(2, "S01E02"))
+    def test_multiples_get_log_msg(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
+        batch_rename.append(2, 1, [2])
         assert batch_rename.get_log_message() == "S01E01, S01E02"
 
-    def test_singular_get_file_ids(self) -> None:
-        batch_rename = BatchRename()
-        batch_rename.append(Rename(1, "S01E01"))
+    def test_multi_episode_file_get_log_msg(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1, 2])
+        assert batch_rename.get_log_message() == "S01E01-02"
+
+    def test_multiple_multi_episode_file_get_log_msg(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
+        batch_rename.append(2, 1, [2, 3])
+
+        assert batch_rename.get_log_message() == "S01E01, S01E02-03"
+
+    def test_singular_get_file_ids(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
         assert batch_rename.get_file_ids() == [1]
 
-    def test_multiple_get_file_ids(self) -> None:
-        batch_rename = BatchRename()
-        batch_rename.append(Rename(1, "S01E01"))
-        batch_rename.append(Rename(2, "S01E02"))
+    def test_multiple_get_file_ids(self, batch_rename) -> None:
+        batch_rename.append(1, 1, [1])
+        batch_rename.append(2, 1, [2])
         assert batch_rename.get_file_ids() == [1, 2]

--- a/tests/test_existing_renamer.py
+++ b/tests/test_existing_renamer.py
@@ -1,12 +1,7 @@
 import logging
-from datetime import timedelta
-from typing import List
 
 from existing_renamer import ExistingRenamer
 from pycliarr.api import SonarrCli
-from pycliarr.api.base_api import json_data
-
-from tests.conftest import episode_data, file_info
 
 
 class TestExistingRenamer:
@@ -23,136 +18,164 @@ class TestExistingRenamer:
         assert not rename_files.called
 
     def test_when_series_returned_no_episodes(self, get_serie, caplog, mocker) -> None:
-        mocker.patch.object(SonarrCli, "get_episode").return_value = []
+        mocker.patch.object(SonarrCli, "request_get").return_value = []
         rename_files = mocker.patch.object(SonarrCli, "rename_files")
 
         with caplog.at_level(logging.DEBUG):
             ExistingRenamer("test", "test.tld", "test-api-key").scan()
 
-        assert "Starting Existing Renamer" in caplog.text
         assert "Retrieved series list" in caplog.text
-        assert "Error fetching episode list" in caplog.text
+        assert "No episodes to rename" in caplog.text
         assert not rename_files.called
 
-    def test_when_episodes_filtered_out(self, get_serie, caplog, mocker) -> None:
-        episodes: List[json_data] = [
-            episode_data(
-                id=1,
-                title="TBA",
-                airDateDelta=timedelta(hours=2),
-                seasonNumber=0,
-            ),
-            episode_data(
-                id=2,
-                title="TBA",
-                airDateDelta=timedelta(hours=8),
-            ),
-            dict(id=3, title="NOT TBA", airDateUtc=None, seasonNumber=1, hasFile=False),
+    def test_when_episode_need_renamed(self, get_serie, caplog, mocker) -> None:
+        mocker.patch.object(SonarrCli, "request_get").return_value = [
+            dict(seasonNumber=1, episodeNumbers=[1], episodeFileId=1)
         ]
-        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
         rename_files = mocker.patch.object(SonarrCli, "rename_files")
 
         with caplog.at_level(logging.DEBUG):
             ExistingRenamer("test", "test.tld", "test-api-key").scan()
 
-        assert "Starting Existing Renamer" in caplog.text
-        assert "Retrieved series list" in caplog.text
-        assert "No rename needed" in caplog.text
-        assert not rename_files.called
-
-    def test_when_episode_file_name_contains_TBA(
-        self, get_serie, caplog, mocker
-    ) -> None:
-        episodes: List[json_data] = [
-            episode_data(
-                id=1,
-                title="NOT TBA",
-                airDateDelta=timedelta(days=-1),
-                seasonNumber=1,
-            ),
-        ]
-        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
-        rename_files = mocker.patch.object(SonarrCli, "rename_files")
-
-        file: json_data = file_info(
-            id=1,
-            file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
-        )
-
-        mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
-
-        with caplog.at_level(logging.DEBUG):
-            ExistingRenamer("test", "test.tld", "test-api-key").scan()
-
-        assert "S01E01 Queuing for rename" in caplog.text
+        assert "Found episodes to be renamed" in caplog.text
         assert "Renaming S01E01" in caplog.text
         rename_files.assert_called_once_with([1], 1)
 
-    def test_when_renaming_multiple_files(self, get_serie, caplog, mocker) -> None:
-        episodes: List[json_data] = [
-            episode_data(
-                id=1,
-                title="NOT TBA",
-                airDateDelta=timedelta(days=-1),
-                seasonNumber=1,
-                episodeNumber=1,
-            ),
-            episode_data(
-                id=2,
-                title="NOT TBA",
-                airDateDelta=timedelta(days=-1),
-                seasonNumber=1,
-                episodeNumber=2,
-            ),
+    def test_when_multiple_episodes_need_renamed(
+        self, get_serie, caplog, mocker
+    ) -> None:
+        mocker.patch.object(SonarrCli, "request_get").return_value = [
+            dict(seasonNumber=1, episodeNumbers=[1], episodeFileId=1),
+            dict(seasonNumber=1, episodeNumbers=[2], episodeFileId=2),
         ]
-        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
         rename_files = mocker.patch.object(SonarrCli, "rename_files")
-
-        file1: json_data = file_info(
-            id=1,
-            file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
-        )
-
-        file2: json_data = file_info(
-            id=2,
-            file_name="The Series Titles (2010) - S01E02 - TBA.mkv",
-        )
-
-        get_episode_file = mocker.patch.object(SonarrCli, "get_episode_file")
-        get_episode_file.return_value = file1
-        get_episode_file.side_effect = [file1, file2]
 
         with caplog.at_level(logging.DEBUG):
             ExistingRenamer("test", "test.tld", "test-api-key").scan()
 
-        assert "S01E01 Queuing for rename" in caplog.text
-        assert "S01E02 Queuing for rename" in caplog.text
+        assert "Found episodes to be renamed" in caplog.text
         assert "Renaming S01E01, S01E02" in caplog.text
         rename_files.assert_called_once_with([1, 2], 1)
 
-    def test_when_episode_file_name_does_not_contain_TBA(
-        self, get_serie, caplog, mocker
-    ) -> None:
-        episodes: List[json_data] = [
-            episode_data(
-                id=1,
-                title="NOT TBA",
-                airDateDelta=timedelta(days=-1),
-                seasonNumber=1,
-            ),
-        ]
-        mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
-        rename_files = mocker.patch.object(SonarrCli, "rename_files")
+    # def test_when_episodes_filtered_out(self, get_serie, caplog, mocker) -> None:
+    #     episodes: List[json_data] = [
+    #         episode_data(
+    #             id=1,
+    #             title="TBA",
+    #             airDateDelta=timedelta(hours=2),
+    #             seasonNumber=0,
+    #         ),
+    #         episode_data(
+    #             id=2,
+    #             title="TBA",
+    #             airDateDelta=timedelta(hours=8),
+    #         ),
+    #         dict(id=3, title="NOT TBA", airDateUtc=None, seasonNumber=1, hasFile=False),
+    #     ]
+    #     mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+    #     rename_files = mocker.patch.object(SonarrCli, "rename_files")
 
-        file: json_data = file_info(
-            id=1,
-            file_name="The Series Titles (2010) - S01E01 - Episode1.mkv",
-        )
+    #     with caplog.at_level(logging.DEBUG):
+    #         ExistingRenamer("test", "test.tld", "test-api-key").scan()
 
-        mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
+    #     assert "Starting Existing Renamer" in caplog.text
+    #     assert "Retrieved series list" in caplog.text
+    #     assert "No rename needed" in caplog.text
+    #     assert not rename_files.called
 
-        with caplog.at_level(logging.DEBUG):
-            ExistingRenamer("test", "test.tld", "test-api-key").scan()
+    # def test_when_episode_file_name_contains_TBA(
+    #     self, get_serie, caplog, mocker
+    # ) -> None:
+    #     episodes: List[json_data] = [
+    #         episode_data(
+    #             id=1,
+    #             title="NOT TBA",
+    #             airDateDelta=timedelta(days=-1),
+    #             seasonNumber=1,
+    #         ),
+    #     ]
+    #     mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+    #     rename_files = mocker.patch.object(SonarrCli, "rename_files")
 
-        assert "No rename needed" in caplog.text
-        assert not rename_files.called
+    #     file: json_data = file_info(
+    #         id=1,
+    #         file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
+    #     )
+
+    #     mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
+
+    #     with caplog.at_level(logging.DEBUG):
+    #         ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+    #     assert "S01E01 Queuing for rename" in caplog.text
+    #     assert "Renaming S01E01" in caplog.text
+    #     rename_files.assert_called_once_with([1], 1)
+
+    # def test_when_renaming_multiple_files(self, get_serie, caplog, mocker) -> None:
+    #     episodes: List[json_data] = [
+    #         episode_data(
+    #             id=1,
+    #             title="NOT TBA",
+    #             airDateDelta=timedelta(days=-1),
+    #             seasonNumber=1,
+    #             episodeNumber=1,
+    #         ),
+    #         episode_data(
+    #             id=2,
+    #             title="NOT TBA",
+    #             airDateDelta=timedelta(days=-1),
+    #             seasonNumber=1,
+    #             episodeNumber=2,
+    #         ),
+    #     ]
+    #     mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+    #     rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+    #     file1: json_data = file_info(
+    #         id=1,
+    #         file_name="The Series Titles (2010) - S01E01 - TBA.mkv",
+    #     )
+
+    #     file2: json_data = file_info(
+    #         id=2,
+    #         file_name="The Series Titles (2010) - S01E02 - TBA.mkv",
+    #     )
+
+    #     get_episode_file = mocker.patch.object(SonarrCli, "get_episode_file")
+    #     get_episode_file.return_value = file1
+    #     get_episode_file.side_effect = [file1, file2]
+
+    #     with caplog.at_level(logging.DEBUG):
+    #         ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+    #     assert "S01E01 Queuing for rename" in caplog.text
+    #     assert "S01E02 Queuing for rename" in caplog.text
+    #     assert "Renaming S01E01, S01E02" in caplog.text
+    #     rename_files.assert_called_once_with([1, 2], 1)
+
+    # def test_when_episode_file_name_does_not_contain_TBA(
+    #     self, get_serie, caplog, mocker
+    # ) -> None:
+    #     episodes: List[json_data] = [
+    #         episode_data(
+    #             id=1,
+    #             title="NOT TBA",
+    #             airDateDelta=timedelta(days=-1),
+    #             seasonNumber=1,
+    #         ),
+    #     ]
+    #     mocker.patch.object(SonarrCli, "get_episode").return_value = episodes
+    #     rename_files = mocker.patch.object(SonarrCli, "rename_files")
+
+    #     file: json_data = file_info(
+    #         id=1,
+    #         file_name="The Series Titles (2010) - S01E01 - Episode1.mkv",
+    #     )
+
+    #     mocker.patch.object(SonarrCli, "get_episode_file").return_value = file
+
+    #     with caplog.at_level(logging.DEBUG):
+    #         ExistingRenamer("test", "test.tld", "test-api-key").scan()
+
+    #     assert "No rename needed" in caplog.text
+    #     assert not rename_files.called


### PR DESCRIPTION
This is a rewrite of the `existing_renamer` feature

I'm now leveraging the `/api/v3/rename` endpoint, which will return a list of files, which need to be renamed. Including TBA episodes, or episodes whose filename doesn't match the existing mediaFormat.

I also added a check on the `series_scanner` to ensure that `Episode Title Required` is set to `always`