### PR TITLE
fixes #20 Optional job config settings

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -23,16 +23,29 @@ CONFIG_SCHEMA = {
                     lambda s: len(s) > 0,
                     error="sonarr[].api_key is a required field",
                 ),
-                "series_scanner": {
-                    "enabled": bool,
+                Optional(
+                    "series_scanner",
+                    default=dict(
+                        enabled=False,
+                        hourly_job=False,
+                        hours_before_air=4,
+                    ),
+                    ignore_extra_keys=True,
+                ): {
+                    Optional("enabled", default=False): bool,
                     Optional("hourly_job", default=False): bool,
                     Optional("hours_before_air", default=4): int,
                 },
-                "existing_renamer": {
-                    "enabled": bool,
+                Optional(
+                    "existing_renamer",
+                    default=dict(enabled=False, hourly_job=False),
+                    ignore_extra_keys=True,
+                ): {
+                    Optional("enabled", default=False): bool,
                     Optional("hourly_job", default=False): bool,
                 },
             }
         ],
+        ignore_extra_keys=True,
     ),
 }

--- a/src/main.py
+++ b/src/main.py
@@ -76,6 +76,18 @@ class Main:
             exit(1)
 
         for sonarr_config in config.sonarr:
+            if (
+                not sonarr_config.series_scanner.enabled
+                and not sonarr_config.existing_renamer.enabled
+            ):
+                with logger.contextualize(instance=sonarr_config.name):
+                    logger.warning(
+                        "Possible config error? -- No jobs configured for current instance"
+                    )
+                    logger.warning(
+                        "Please see example config for comparison -- https://github.com/hollanbm/sonarr-series-scanner/blob/main/docker/config.yml.example"
+                    )
+                    continue
             if sonarr_config.series_scanner.enabled:
                 self.__schedule_series_scanner(sonarr_config)
             if sonarr_config.existing_renamer.enabled:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from config_schema import CONFIG_SCHEMA
 from existing_renamer import ExistingRenamer
 from main import Main
 from pyconfigparser import Config, configparser
+from schedule import Job
 from series_scanner import SeriesScanner
 
 # disable config caching
@@ -10,46 +11,65 @@ configparser.hold_an_instance = False
 
 
 class TestMain:
-    def get_single_config(self) -> Config:
+    @pytest.fixture
+    def config(self) -> Config:
         return configparser.get_config(
             CONFIG_SCHEMA,
             config_dir="tests/fixtures",
             file_name="single_sonarr.yml",
         )
 
-    @pytest.fixture
-    def all_disabled(self, mocker):
-        mocker.patch(
-            "pyconfigparser.configparser.get_config"
-        ).return_value = self.get_single_config()
-
-    @pytest.fixture
-    def series_scanner_enabled(self, mocker):
-        config = self.get_single_config()
-        config.sonarr[0].series_scanner.enabled = True
+    def test_all_disabled(self, config, mocker) -> None:
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
 
-    @pytest.fixture
-    def existing_renamer_enabled(self, mocker):
-        config = self.get_single_config()
-        config.sonarr[0].existing_renamer.enabled = True
-        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
-
-    def test_all_disabled(self, all_disabled, mocker):
         series_scanner = mocker.patch.object(SeriesScanner, "scan")
         existing_renamer = mocker.patch.object(ExistingRenamer, "scan")
+
+        Main().start()
 
         assert not series_scanner.called
         assert not existing_renamer.called
 
-    def test_series_scanner_scan(self, series_scanner_enabled, mocker) -> None:
+    def test_series_scanner_scan(self, config, mocker) -> None:
+        config.sonarr[0].series_scanner.enabled = True
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        mocker.patch.object(Job, "do")
+
         series_scanner = mocker.patch.object(SeriesScanner, "scan")
 
         Main().start()
         assert series_scanner.called
 
-    def test_existing_renamer_scan(self, existing_renamer_enabled, mocker) -> None:
+    def test_series_scanner_hourly_job(self, config, mocker) -> None:
+        config.sonarr[0].series_scanner.enabled = True
+        config.sonarr[0].series_scanner.hourly_job = True
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        job = mocker.patch.object(Job, "do")
+
+        series_scanner = mocker.patch.object(SeriesScanner, "scan")
+
+        Main().start()
+        assert series_scanner.called
+        assert job.called
+
+    def test_existing_renamer_scan(self, config, mocker) -> None:
+        config.sonarr[0].existing_renamer.enabled = True
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        mocker.patch.object(Job, "do")
+
         existing_renamer = mocker.patch.object(ExistingRenamer, "scan")
 
         Main().start()
         assert existing_renamer.called
+
+    def test_existing_renamer_hourly_job(self, config, mocker) -> None:
+        config.sonarr[0].existing_renamer.enabled = True
+        config.sonarr[0].existing_renamer.hourly_job = True
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        job = mocker.patch.object(Job, "do")
+
+        existing_renamer = mocker.patch.object(ExistingRenamer, "scan")
+
+        Main().start()
+        assert existing_renamer.called
+        assert job.called


### PR DESCRIPTION
- Update config schema, to make `series_scanner` and `existing_renamer` optional
	- defaults to False
- If no jobs have been enabled, display warning message to user