### PR TITLE
fixes #221, switch from wolfi to docker hardened debian, build additional `-dev` images

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -41,6 +41,15 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Verify Docker Hardened Images token
+        env:
+          DHI_PAT: ${{ secrets.DHI_PAT }}
+        run: |
+          if [ -z "$DHI_PAT" ]; then
+            echo "::error title=Missing secret::DHI_PAT must be configured for this workflow."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -18,13 +18,25 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  DHI_REGISTRY: dhi.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:
     # Only build PR images when explicitly requested via label.
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-image') }}
+    name: Docker image (${{ matrix.variant.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - name: runtime
+            runtime_image: dhi.io/debian-base:trixie
+            tag_suffix: ""
+          - name: runtime-dev
+            runtime_image: dhi.io/debian-base:trixie-dev
+            tag_suffix: "-dev"
     permissions:
       contents: read
       packages: write
@@ -46,13 +58,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hardened Images registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DHI_REGISTRY }}
+          username: ${{ vars.DHI_USERNAME }}
+          password: ${{ secrets.DHI_PAT }}
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            suffix=${{ matrix.variant.tag_suffix }},onlatest=true
           tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
             type=raw,value=pr-${{ github.event.pull_request.number }}-{{sha}},enable=${{ github.event_name == 'pull_request' }}
             type=raw,value={{branch}},enable=${{ github.event_name == 'push' }}
@@ -78,6 +101,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            RUNTIME_IMAGE=${{ matrix.variant.runtime_image }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ COPY --from=builder --chown=nonroot:nonroot /renamarr /renamarr
 
 WORKDIR /renamarr
 
+USER nonroot
+
 # default settings
 ENV LOGURU_DIAGNOSE="NO"
 ENV LOG_LEVEL="INFO"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG UV_VERSION=0.11.6
+ARG RUNTIME_IMAGE=dhi.io/debian-base:trixie
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION}-debian AS builder
 
@@ -21,29 +22,24 @@ COPY . /renamarr
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync
 
-# chainguard secure distroless base image
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:70750dfde91b4c5804b4df269121253fbdff73a9122925c7acc067aa33f9f55e AS runtime
+RUN mkdir -p /config /logs
+
+# Docker Hardened Images Debian runtime base image
+FROM ${RUNTIME_IMAGE} AS runtime
 
 # Grab python from the builder
 COPY --from=builder --chown=nonroot:nonroot /python /python
+COPY --from=builder --chown=nonroot:nonroot /config /config
+COPY --from=builder --chown=nonroot:nonroot /logs /logs
+COPY --from=builder --chown=nonroot:nonroot /renamarr /renamarr
 
 WORKDIR /renamarr
-
-# Copy the application from the builder
-COPY --from=builder --chown=nonroot:nonroot /renamarr /renamarr
 
 # default settings
 ENV LOGURU_DIAGNOSE="NO"
 ENV LOG_LEVEL="INFO"
 ENV CONFIG_DIR="/"
 ENV LOG_DIR="/logs"
-
-# Prepare the default config and log directories for the nonroot runtime user.
-RUN mkdir -p /config /logs && \
-    chown -R nonroot:nonroot /config /logs
-
-RUN apk add --no-cache tzdata
-USER nonroot
 
 # activate venv
 ENV PATH="/renamarr/.venv/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
    - See [Configuration](#configuration) for further explanation
 3. Bring up app using provided [docker-compose.yml](example/docker-compose.yml)
 
+#### Troubleshooting
+
+Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage
+
 ## How it works
 
 ### Renamarr

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 #### Troubleshooting
 
-Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage
+Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage.
 
 ## How it works
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   renamarr:
     container_name: renamarr
-    image: ghcr.io/hollanbm/renamarr:latest@sha256:2e9ea61020162b7b23cb864aa63a148ae496661942709da535e83f182734107c
+    image: ghcr.io/hollanbm/renamarr:latest
     # user: 1000:1000 # if using the log_to_file feature, recommended to set the container user to match the host user to avoid permission issues with log files.
     restart: unless-stopped
     volumes:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>hollanbm/renovate-config"],
+  "pinDigests": false,
   "minimumReleaseAge": "14 days",
   "packageRules": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker now builds and distributes multiple image variants (standard and development) across multiple registries for flexible deployment options.

* **Documentation**
  * Added troubleshooting guidance clarifying that development-tagged images are intended for diagnostic purposes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->