### PR TITLE
fixes #226 - remove existing renamer

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -33,10 +33,10 @@ jobs:
         variant:
           - name: runtime
             runtime_image: dhi.io/debian-base:trixie
-            tag_suffix: ""
+            tag_suffix: ''
           - name: runtime-dev
             runtime_image: dhi.io/debian-base:trixie-dev
-            tag_suffix: "-dev"
+            tag_suffix: -dev
     permissions:
       contents: read
       packages: write
@@ -49,13 +49,10 @@ jobs:
             echo "::error title=Missing secret::DHI_PAT must be configured for this workflow."
             exit 1
           fi
-
       - name: Checkout repository
         uses: actions/checkout@v6
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -66,7 +63,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Log in to Docker Hardened Images registry
         uses: docker/login-action@v4
         with:
@@ -102,7 +98,6 @@ jobs:
             org.opencontainers.image.description=${{ github.event.repository.description }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -21,26 +21,20 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
-          architecture: "x64"
-
+          python-version: '3.14'
+          architecture: x64
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-
       - name: Install dependencies
         run: uv sync --frozen --group dev --group test
-
       - name: Test with pytest
         run: uv run pytest --cov-branch --cov=src --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy tests
-
       - name: Lint with Ruff
         run: uv run ruff check --output-format=github .
-
       - name: Scan dependencies with uv-secure
         run: uv run uv-secure
-
       - name: Upload coverage
         uses: codecov/codecov-action@v6
         with:
@@ -49,7 +43,6 @@ jobs:
           disable_search: true
           files: ./coverage.xml
           fail_ci_if_error: true
-
       - name: Upload test results to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -13,6 +13,7 @@ on:
   pull_request:
     paths:
       - renovate.json
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -21,4 +22,4 @@ jobs:
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.1.0
         with:
           config_file_path: renovate.json
-          strict: "true"
+          strict: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 config.yml
-.pre-commit-cache
-.prek-home
+.prek-home/
 junit.xml
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,linux,python,pycharm+all,visualstudiocode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,36 @@
 repos:
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.7
+    hooks:
+      - id: uv-lock
+        files: ^(pyproject\.toml|uv\.lock|uv-secure\.toml)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.10
+    rev: v0.15.11
     hooks:
       - id: ruff-check
-        args: [--fix]
+        args:
+          - --fix
       - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: \.md$
+      - id: end-of-file-fixer
+  - repo: https://github.com/lyz-code/yamlfix
+    rev: 1.19.1
+    hooks:
+      - id: yamlfix
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-footnote
+          - mdformat-frontmatter
+          - mdformat-gfm
+          - mdformat-gfm-alerts
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -18,20 +43,6 @@ repos:
       - id: check-renovate
       - id: check-compose-spec
       - id: check-github-workflows
-  - repo: https://github.com/hukkin/mdformat
-    rev: 1.0.0
-    hooks:
-      - id: mdformat
-        additional_dependencies:
-        - mdformat-footnote
-        - mdformat-frontmatter
-        - mdformat-gfm
-        - mdformat-gfm-alerts
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.6
-    hooks:
-      - id: uv-lock
-        files: ^(pyproject\.toml|uv\.lock|uv-secure\.toml)
   - repo: local
     hooks:
       - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,12 @@ repos:
         files: ^(pyproject\.toml|uv\.lock|uv-secure\.toml)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.11
+    rev: v0.15.10
     hooks:
       - id: ruff-check
         args:
           - --fix
       - id: ruff-format
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: trailing-whitespace
-        exclude: \.md$
-      - id: end-of-file-fixer
   - repo: https://github.com/lyz-code/yamlfix
     rev: 1.19.1
     hooks:

--- a/.yamlfix.toml
+++ b/.yamlfix.toml
@@ -1,0 +1,5 @@
+whitelines = 1
+section_whitelines = 1
+sequence_style = "block_style"
+line_length = 9999
+explicit_start = false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,1 +1,0 @@
-extends: default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UV_VERSION=0.11.6
+ARG UV_VERSION=0.11.7
 ARG RUNTIME_IMAGE=dhi.io/debian-base:trixie
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION}-debian AS builder

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     environment:
       LOG_LEVEL: DEBUG
-    restart: "no"
+    restart: 'no'
     volumes:
       - ./config/config.yml:/config/config.yml:ro
       - ./logs:/logs:rw

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   renamarr:
     container_name: renamarr
     image: ghcr.io/hollanbm/renamarr:latest
-    # user: 1000:1000 # if using the log_to_file feature, recommended to set the container user to match the host user to avoid permission issues with log files.
+    # user: 1000:1000  # if using the log_to_file feature, recommended to set the container user to match the host user to avoid permission issues with log files.
     restart: unless-stopped
     volumes:
       - ./config.yml:/config/config.yml:ro
-      # - ./logs:/logs:rw # If using the log_to_file option, uncomment this line to persist logs to the host machine. **Don't forget to create logs folder first**
+      # - ./logs:/logs:rw  # If using the log_to_file option, uncomment this line to persist logs to the host machine. **Don't forget to create logs folder first**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ test = [
 
 # Treat this repo as an application, so uv installs dependencies without packaging renamarr itself.
 [tool.uv]
-required-version = "==0.11.6"
+required-version = "==0.11.7"
 package = false
 environments = [
   "sys_platform == 'darwin'",

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -40,16 +40,6 @@ CONFIG_SCHEMA = {
                     Optional("hourly_job", default=False): bool,
                     Optional("hours_before_air", default=4): int,
                 },
-                # keeping for backwards compatibility between v1.0.0 and v0.5
-                Optional(
-                    "existing_renamer",
-                    default=dict(enabled=False, hourly_job=False, analyze_files=False),
-                    ignore_extra_keys=True,
-                ): {
-                    Optional("enabled", default=False): bool,
-                    Optional("hourly_job", default=False): bool,
-                    Optional("analyze_files", default=False): bool,
-                },
                 Optional(
                     "renamarr",
                     default=dict(

--- a/src/main.py
+++ b/src/main.py
@@ -156,8 +156,8 @@ class Main:
             exit(1)
 
         for sonarr_config in config.sonarr:
-            if not sonarr_config.series_scanner.enabled and not (
-                sonarr_config.renamarr.enabled or sonarr_config.existing_renamer.enabled
+            if not (
+                sonarr_config.series_scanner.enabled or sonarr_config.renamarr.enabled
             ):
                 with logger.contextualize(instance=sonarr_config.name):
                     logger.warning(
@@ -172,14 +172,6 @@ class Main:
             if sonarr_config.renamarr.enabled:
                 if sonarr_config.renamarr.log_to_file:
                     self.__configure_file_logging("sonarr", sonarr_config.name)
-                self.__schedule_sonarr_renamarr(sonarr_config)
-            elif sonarr_config.existing_renamer.enabled:
-                logger.warning(
-                    "sonarr[].existing_renamer config option, has been renamed to sonarr[].renamarr. Please update config, as this will stop working in future versions"
-                )
-                logger.warning(
-                    "Please see example config for comparison -- https://github.com/hollanbm/renamarr/blob/main/example/config.yml.example"
-                )
                 self.__schedule_sonarr_renamarr(sonarr_config)
 
         for radarr_config in config.radarr:

--- a/tests/fixtures/disabled.yml
+++ b/tests/fixtures/disabled.yml
@@ -3,32 +3,33 @@ sonarr:
     url: https://sonarr.tld
     api_key: sonarr-api-key
     series_scanner:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false
       hours_before_air: 2
     renamarr:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false
   - name: sonarr1
     url: https://sonarr1.tld
     api_key: sonarr1-api-key
     series_scanner:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false
       hours_before_air: 4
     renamarr:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false
+
 radarr:
   - name: radarr
     url: https://radarr.tld
     api_key: radarr-api-key
     renamarr:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false
   - name: radarr1
     url: https://radarr1.tld
     api_key: radarr1-api-key
     renamarr:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false

--- a/tests/fixtures/legacy_sonarr.yml
+++ b/tests/fixtures/legacy_sonarr.yml
@@ -3,5 +3,5 @@ sonarr:
     url: https://sonarr.tld
     api_key: sonarr-api-key
     existing_renamer:
-      enabled: False
-      hourly_job: False
+      enabled: false
+      hourly_job: false

--- a/tests/fixtures/legacy_sonarr.yml
+++ b/tests/fixtures/legacy_sonarr.yml
@@ -1,7 +1,0 @@
-sonarr:
-  - name: sonarr
-    url: https://sonarr.tld
-    api_key: sonarr-api-key
-    existing_renamer:
-      enabled: false
-      hourly_job: false

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,14 +78,6 @@ class TestMain:
             file_name="disabled.yml",
         )
 
-    @pytest.fixture
-    def legacy_sonarr_config(self) -> Generator:
-        yield configparser.get_config(
-            CONFIG_SCHEMA,
-            config_dir="tests/fixtures",
-            file_name="legacy_sonarr.yml",
-        )
-
     def test_all_disabled(self, config, mocker) -> None:
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
 
@@ -388,59 +380,6 @@ class TestMain:
         )
         assert isinstance(mock_loguru_error.call_args_list[-1].args[0], OSError)
         assert excinfo.value.code == 1
-
-    def test_legacy_config_existing_renamer_enabled(
-        self, mocker, legacy_sonarr_config, mock_loguru_warning
-    ):
-        legacy_sonarr_config.sonarr[0].existing_renamer.enabled = True
-
-        mocker.patch(
-            "pyconfigparser.configparser.get_config"
-        ).return_value = legacy_sonarr_config
-
-        mocker.patch.object(Job, "do")
-
-        mocker.patch.object(SonarrSeriesScanner, "scan")
-        sonarr_renamarr = mocker.patch.object(SonarrRenamarr, "scan")
-        mocker.patch.object(RadarrRenamarr, "scan")
-
-        Main().start()
-
-        sonarr_renamarr.assert_called()
-
-        mock_loguru_warning.assert_any_call(
-            "sonarr[].existing_renamer config option, has been renamed to sonarr[].renamarr. Please update config, as this will stop working in future versions"
-        )
-
-        mock_loguru_warning.assert_any_call(
-            "Please see example config for comparison -- https://github.com/hollanbm/renamarr/blob/main/example/config.yml.example"
-        )
-
-    def test_legacy_config_existing_renamer_exception(
-        self, mocker, legacy_sonarr_config, mock_loguru_error
-    ):
-        legacy_sonarr_config.sonarr[0].existing_renamer.enabled = True
-
-        mocker.patch(
-            "pyconfigparser.configparser.get_config"
-        ).return_value = legacy_sonarr_config
-
-        mocker.patch.object(Job, "do")
-
-        exception = CliArrError("BOOM!")
-
-        sonarr_renamarr = mocker.patch.object(SonarrRenamarr, "scan")
-        sonarr_renamarr.side_effect = exception
-        contextualize = mocker.patch.object(
-            logger, "contextualize", return_value=nullcontext()
-        )
-
-        Main().start()
-
-        contextualize.assert_any_call(
-            service="sonarr", instance=legacy_sonarr_config.sonarr[0].name
-        )
-        mock_loguru_error.assert_called_once_with(exception)
 
     def test_radarr_renamarr_scan(self, config, mocker) -> None:
         config.radarr[0].renamarr.enabled = True


### PR DESCRIPTION
- **add yamlfix, and standardize yaml, uprade uv to 0.11.7**
- **remove existing_renamer setting**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed `existing_renamer` configuration option

* **Chores**
  * Updated uv to 0.11.7 and ruff to v0.15.11
  * Added YAML formatting and validation tools
  * Standardized configuration and workflow file formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->