### PR TITLE
dont update latest tag for prelease images

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -80,7 +80,7 @@ jobs:
             latest=false
             suffix=${{ matrix.variant.tag_suffix }},onlatest=true
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
             type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
             type=raw,value=pr-${{ github.event.pull_request.number }}-{{sha}},enable=${{ github.event_name == 'pull_request' }}
             type=raw,value={{branch}},enable=${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 #### Troubleshooting
 
-Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage. Pre-release images are published with their release version tag, but do not update `latest` or `latest-dev`.
+Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage. Pre-release images are tagged with their specific release version and do not change or overwrite the `latest` or `latest-dev` tags.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 #### Troubleshooting
 
-Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage.
+Image tags ending in `-dev` can be used for troubleshooting purposes, but are not intended for normal usage. Pre-release images are published with their release version tag, but do not update `latest` or `latest-dev`.
 
 ## How it works
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on pre-release Docker image publishing to clarify that `latest` and `latest-dev` tags are not affected by pre-release releases.

* **Chores**
  * Updated Docker image tag generation to prevent pre-release builds from updating the `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->