### PR TITLE
fixes #232 use posix directory comparison instead of substrings

### DIFF
--- a/src/sonarr_renamarr.py
+++ b/src/sonarr_renamarr.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from pathlib import PurePosixPath
 from time import sleep
 from typing import List
 
@@ -61,11 +62,20 @@ class SonarrRenamarr:
                             path=f"/api/v3/series/{show.id}/folder"
                         )["folder"]
 
+                        # Use path-aware comparisons so overlapping roots, such as
+                        # /data/media/tv and /data/media/tv-anime, stay distinct.
+                        show_path = PurePosixPath(show.path)
+
                         for root_folder in root_folders:
                             root_folder_path = root_folder["path"]
+                            root_path = PurePosixPath(root_folder_path)
+                            expected_show_path = root_path / series_folder
+
+                            # Only move shows already under this root when their
+                            # current path differs from Sonarr's expected folder.
                             if (
-                                root_folder_path in show.path
-                                and f"{root_folder_path}/{series_folder}" != show.path
+                                root_path in show_path.parents
+                                and expected_show_path != show_path
                             ):
                                 bulk_move.add(root_folder_path, show.id)
                                 logger.debug(

--- a/tests/test_sonarr_renamarr.py
+++ b/tests/test_sonarr_renamarr.py
@@ -337,3 +337,41 @@ class TestSonarrRenamarr:
         mock_loguru_info.assert_any_call(
             "Series folder rename successful for series IDs: 1"
         )
+
+    def test_when_root_folder_paths_overlap_uses_matching_root(
+        self, mock_loguru_debug, mocker
+    ) -> None:
+        show = SimpleNamespace(
+            id=1, title="Anime Show", path="/data/media/tv-anime/OldName"
+        )
+        mocker.patch.object(SonarrCli, "get_serie").return_value = [show]
+        mocker.patch.object(SonarrCli, "get_root_folder").return_value = [
+            dict(path="/data/media/tv"),
+            dict(path="/data/media/tv-anime"),
+        ]
+        mocker.patch.object(SonarrCli, "request_get").side_effect = [
+            dict(folder="NewName"),
+            [],
+        ]
+        request_put = mocker.patch.object(SonarrCli, "request_put")
+        mocker.patch.object(
+            SonarrRenamarr, "_SonarrRenamarr__rescan_series", return_value=True
+        )
+
+        SonarrRenamarr(
+            "test",
+            "test.tld",
+            "test-api-key",
+            analyze_files=False,
+            rename_folders=True,
+        ).scan()
+
+        mock_loguru_debug.assert_any_call("Processing pending series folder renames")
+        request_put.assert_called_once_with(
+            path="/api/v3/series/editor",
+            json_data=dict(
+                rootFolderPath="/data/media/tv-anime",
+                seriesIds=[1],
+                moveFiles=True,
+            ),
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced folder-move logic to correctly identify when shows need relocation with overlapping root folder paths. The system now uses path-aware comparisons to ensure the correct root folder is selected and files are moved to the appropriate location.

* **Tests**
  * Added test coverage for overlapping root folder path scenarios to ensure proper handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->